### PR TITLE
update: support for angular 14 and above

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mathjax-angular-project",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mathjax-angular-project",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^14.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjax-angular-project",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A quick way to implement Mathjax v3 into your Angular project!",
   "homepage": "https://github.com/sajivkumar/mathjax-angular/blob/main/README.md",
   "repository": {

--- a/projects/mathjax-lib/README.md
+++ b/projects/mathjax-lib/README.md
@@ -10,6 +10,12 @@ This plugins implements the browser version of [Mathjax v3][1] into [Angular][2]
 
 This library helps you implement the version 3 of Mathjax into any of your angular web application.
 
+## Compatibility
+
+`mathjax-angular` is now compatible with **Angular versions 14 and above**, ensuring broader usability across different Angular projects. This library has been tested and confirmed to work with Angular versions 14 through 17.
+
+While it is intended to be compatible with future Angular versions, if you encounter any issues with Angular versions newer than 17, please feel free to [raise an issue](9).
+
 ## Install
 
 Below are the steps you need to use this library.
@@ -138,3 +144,4 @@ For more info and help with the mathjax library refer to [their site][1].
 [6]: http://docs.mathjax.org/en/latest/web/configuration.html#configuring-and-loading-mathjax
 [7]: https://cdnjs.com/libraries/mathjax
 [8]: https://github.com/angular/angular-cli
+[9]: https://github.com/sajivkumar/mathjax-angular/issues

--- a/projects/mathjax-lib/package.json
+++ b/projects/mathjax-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjax-angular",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A quick way to implement Mathjax v3 into your Angular project!",
   "homepage": "https://github.com/sajivkumar/mathjax-angular/blob/main/README.md",
   "repository": {

--- a/projects/mathjax-lib/package.json
+++ b/projects/mathjax-lib/package.json
@@ -12,8 +12,8 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": "^14.0.0",
-    "@angular/core": "^14.0.0"
+    "@angular/common": ">=14.0.0",
+    "@angular/core": ">=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.4.0"


### PR DESCRIPTION
closes #26, fixes #27

This PR addresses the peer dependency limitations of `mathjax-angular` for Angular versions above 14, as discussed in [#27](https://github.com/sajivkumar/mathjax-angular/issues/27). It expands compatibility to newer Angular versions, ensuring broader usability.

### Changes
Updated `peerDependencies` in `package.json` to `>=14.0.0` for `@angular/common` and `@angular/core`. 
This change allows compatibility with Angular versions 14 and above, including the latest releases.
> Since the code and package worked just fine, only installation was an issue for angular versions 15 and above, which was tackled with `npm i --force`, or `npm i --legacy-peer-deps`

> I could have gone with `"^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"`, but since the library seems to work with all the upcoming versions, `>=14.0.0` seemed like the correct option for `@angular/common` and `@angular/core`. 

### Context
The need for this update was highlighted in issue [#27](https://github.com/sajivkumar/mathjax-angular/issues/27) and further reinforced by community feedback, particularly the suggestion from [@marcinstl](https://github.com/marcinstl). The update ensures that `mathjax-angular` remains a viable option for projects using newer versions of Angular.

### Testing
Basic functionality tests were conducted across Angular versions:
- 14, 15 by @mratanusarkar (me)
- 16 by @raztirlea
- 17 by @marcinstl

to confirm the compatibility of the library with various Angular versions.
The library performed as expected in all versions without any compatibility issues.

### Impact
This enhancement simplifies the integration of `mathjax-angular` in projects using Angular versions 14 and above, fostering a more inclusive and up-to-date usage scope. It also solves the deployment issues of angular apps that have dependencies with `mathjax-angular` in Cloud and DevOps pipelines (eg: Oryx in Azure) as discussed in #27  